### PR TITLE
Mobile dark mode: Use same rendering as web (disable CAUTION SVG inlining)

### DIFF
--- a/app/training/lights/page.tsx
+++ b/app/training/lights/page.tsx
@@ -272,7 +272,7 @@ export default function LightsTrainer() {
             const txt = await res.text();
             // Remove the @media (prefers-color-scheme: dark) block entirely
             const cleaned = txt.replace(/@media\s*\(prefers-color-scheme:\s*dark\)\s*\{[\s\S]*?\}/g, "");
-            const isCaution = item.severity === "caution";
+            const isCaution = false;
             if (!isCaution) { setSvgHtml(null); return; }
 
             // Inject white background and normalize to DOOR style only for CAUTION (yellow) lights


### PR DESCRIPTION
- Remove mobile-only SVG inlining/normalization for CAUTION on H125/AS350
- Always render original SVG via <Image>, same as web/desktop
- Keep white procedure card background in dark mode for H125 to ensure contrast

Goal: make mobile dark-mode look identical to web

Local build: OK

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author